### PR TITLE
Save Transcripts correctly on Linux

### DIFF
--- a/transcribe_audio.py
+++ b/transcribe_audio.py
@@ -303,6 +303,7 @@ def main():
         # contributors #
         print(f"\033[4m{Fore.GREEN}Contributors:{Style.RESET_ALL}\033[0m")
         print("@DaniruKun from https://watsonindustries.live")
+        print("[Expletive Deleted] https://evitelpxe.neocities.org")
         exit()
 
     model = set_model_by_ram(args.ram, args.language)

--- a/transcribe_audio.py
+++ b/transcribe_audio.py
@@ -715,22 +715,17 @@ def main():
     if not os.path.isdir('out'):
         os.mkdir('out')
     
-
-    if os.path.isfile('out\\transcription.txt'):
-        print('out\\transcription.txt already exists, changing the name to transcription_1.txt')
-        i = 1
-        while os.path.isfile('out\\transcription_' + str(i) + '.txt'):
-            i += 1
-        transcription_file = open('out\\transcription_' + str(i) + '.txt', 'w', encoding='utf-8')
-    else:
-        transcription_file = open('out\\transcription.txt', 'w', encoding='utf-8')
+    transcript = os.path.join(os.getcwd(), 'out', 'transcription.txt')
+    if os.path.isfile(transcript):
+        transcript = os.path.join(os.getcwd(), 'out', 'transcription_' + str(len(os.listdir('out'))) + '.txt')
+    transcription_file = open(transcript, 'w',  encoding='utf-8')
 
     for original_text, translated_text, language_code in transcription:
         transcription_file.write(f"Original ({language_code}): {original_text}\n")
         if translated_text:
             transcription_file.write(f"Translation: {translated_text}\n")
     transcription_file.close()
-    print(f"Transcription was saved to out\\transcription{'_' + str(i) if i > 0 else ''}.txt")
+    print(f"Transcription was saved to {transcript}")
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem: The transcripts are saved with hardcoded windows paths. On linux, the transcripts would all be dumped in the working directory and have "out\transcript_#" as their filename. See attached image:

![image](https://github.com/cyberofficial/Synthalingua/assets/9963278/43a793b0-cb5f-48c2-b362-345d833e4b52)

Changes:
1. I've used `os.path.join()` which should work properly on linux in addition to windows. 
2. I've replaced the loop that checked if each possible filename exists with `str(len(os.listdir('out')))` to name the files based on how many files are in the output directory.
3. I've removed the redundant print on line 720. It would always say it's renaming the file to transcript_1.txt, even if it was actually renaming it to transcript_42069.txt
4. Since I removed the loop, I also changed the last print command so that it prints the correct path of the saved file.


