### PR TITLE
Var:"reset_text" called before set

### DIFF
--- a/modules/version_checker.py
+++ b/modules/version_checker.py
@@ -1,6 +1,6 @@
 from modules.imports import *
 
-version = "1.0.9979"
+version = "1.0.9980"
 ScriptCreator = "cyberofficial"
 GitHubRepo = "https://github.com/cyberofficial/Synthalingua"
 repo_owner = "cyberofficial"

--- a/transcribe_audio.py
+++ b/transcribe_audio.py
@@ -97,6 +97,7 @@ def main():
     recorder = sr.Recognizer()
     recorder.energy_threshold = args.energy_threshold
     recorder.dynamic_energy_threshold = False
+    reset_text = Style.RESET_ALL
     
     valid_languages = get_valid_languages()
 
@@ -223,7 +224,6 @@ def main():
 
     if args.ram == "1gb" or args.ram == "2gb" or args.ram == "4gb":
         red_text = Style.BRIGHT + Fore.RED
-        reset_text = Style.RESET_ALL
         if not os.path.exists("models/fine_tuned_model_compressed_v2.pt"):
             print("Warning - Since you have chosen a low amount of RAM, the fine-tuned model will be downloaded in a compressed format.\nThis will result in a some what faster startup time and a slower inference time, but will also result in slight reduction in accuracy.")
             print("Compressed Fine-tuned model not found. Downloading Compressed fine-tuned model... [Via OneDrive (Public)]")


### PR DESCRIPTION
* Fixed an issue where reset text was called before setting it. It was moved higher up to the local vars area.


Fixes #51 