### PR TITLE
Fix README format issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 3. *(Optional)* Install [CUDA 12.8](https://developer.nvidia.com/cuda-12-8-0-download-archive) for GPU acceleration if you plan to use GPU features
 4. **Windows**: Run `setup.bat` | **Linux**: See [LINUX_SETUP.md](./LINUX_SETUP.md) for detailed setup instructions
 5. Edit and run the generated batch/bash file, or use the GUI portable version:
-
 Repository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
+
 [<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)
 
 <img src="https://github.com/cyberofficial/Synthalingua/assets/19499442/c81d2c51-bf85-4055-8243-e6a1262cce8a" width=70%>

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 3. *(Optional)* Install [CUDA 12.8](https://developer.nvidia.com/cuda-12-8-0-download-archive) for GPU acceleration if you plan to use GPU features
 4. **Windows**: Run `setup.bat` | **Linux**: See [LINUX_SETUP.md](./LINUX_SETUP.md) for detailed setup instructions
 5. Edit and run the generated batch/bash file, or use the GUI portable version:
+<span></span>
 Repository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
-
+<span></span>
 [<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)
 
 <img src="https://github.com/cyberofficial/Synthalingua/assets/19499442/c81d2c51-bf85-4055-8243-e6a1262cce8a" width=70%>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 4. **Windows**: Run `setup.bat` | **Linux**: See [LINUX_SETUP.md](./LINUX_SETUP.md) for detailed setup instructions
 5. Edit and run the generated batch/bash file, or use the GUI portable version:
 
-[<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)ository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
+Repository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
+[<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)
 
 <img src="https://github.com/cyberofficial/Synthalingua/assets/19499442/c81d2c51-bf85-4055-8243-e6a1262cce8a" width=70%>
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
 2. **Install FFMPEG** ([guide](https://github.com/cyberofficial/Synthalingua/issues/2#issuecomment-1491098222))
 3. *(Optional)* Install [CUDA 12.8](https://developer.nvidia.com/cuda-12-8-0-download-archive) for GPU acceleration if you plan to use GPU features
 4. **Windows**: Run `setup.bat` | **Linux**: See [LINUX_SETUP.md](./LINUX_SETUP.md) for detailed setup instructions
-5. Edit and run the generated batch/bash file, or use the GUI portable version:
-
-Repository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
+5. Edit and run the generated batch/bash file, or use the GUI portable version: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
 
 [<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 3. *(Optional)* Install [CUDA 12.8](https://developer.nvidia.com/cuda-12-8-0-download-archive) for GPU acceleration if you plan to use GPU features
 4. **Windows**: Run `setup.bat` | **Linux**: See [LINUX_SETUP.md](./LINUX_SETUP.md) for detailed setup instructions
 5. Edit and run the generated batch/bash file, or use the GUI portable version:
-<span></span>
+
 Repository: [Synthalingua_Wrapper](https://github.com/cyberofficial/Synthalingua_Wrapper)
-<span></span>
+
 [<img src="https://i.imgur.com/dyZz6u5.png" width=60%>](https://cyberofficial.itch.io/synthalingua)
 
 <img src="https://github.com/cyberofficial/Synthalingua/assets/19499442/c81d2c51-bf85-4055-8243-e6a1262cce8a" width=70%>


### PR DESCRIPTION
Modified the Synthalingua_Wrapper link so that it is within the same line as Step 5 of the Quick Start section. 

Before: 
<img width="1222" height="847" alt="image" src="https://github.com/user-attachments/assets/11ad871c-3cc4-474e-af94-05fcc8c7d3be" />


Here is what it looks like now: 
<img width="1369" height="974" alt="image" src="https://github.com/user-attachments/assets/e5e2421f-3530-4226-822c-10e42e2cb73b" />
