### PR TITLE
Enhance --https argument to accept port numbers for dual HTTP/HTTPS s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ This will save the SRT file as usual and also print its contents to the console 
 | Flag | Description |
 |-----|-----|
 | `--portnumber` | Web server port |
+| `--https` | HTTPS web server port (runs alongside HTTP server) |
 | `--discord_webhook` | Discord webhook URL |
 
 ---
@@ -374,21 +375,36 @@ python synthalingua.py --makecaptions --isolate_vocals --silent_detect --file_in
 ## Web & Discord Integration
 - **Discord:** Use `--discord_webhook` to send results to Discord (long messages are split, rate limits handled)
 - **Web server:** Use `--portnumber` to launch a local Flask server and view subtitles in your browser
+- **HTTPS server:** Use `--https` to launch an HTTPS server with self-signed certificate, can run alongside HTTP
 
 ### Accessing the Web Server
-Once you've launched Synthalingua with the `--portnumber` parameter:
+Once you've launched Synthalingua with web server parameters:
 
+**HTTP Server:**
 1. Open your web browser and navigate to `http://localhost:[PORT]` (replace `[PORT]` with the port number you specified)
 2. Example: `http://localhost:8080` if you used `--portnumber 8080`
-3. For accessing from other devices on your network, use your computer's IP address: `http://[YOUR_IP]:[PORT]`
+
+**HTTPS Server:**
+1. Open your web browser and navigate to `https://localhost:[PORT]` (replace `[PORT]` with the HTTPS port you specified)
+2. Example: `https://localhost:8443` if you used `--https 8443`
+3. Your browser may show a security warning for the self-signed certificate - click "Advanced" and "Proceed" to continue
+
+**Network Access:**
+- For accessing from other devices on your network, use your computer's IP address: `http://[YOUR_IP]:[HTTP_PORT]` or `https://[YOUR_IP]:[HTTPS_PORT]`
 
 **Example usage:**
 ```sh
-# Start Synthalingua with a web server on port 8080
+# Start Synthalingua with HTTP server only
 python synthalingua.py --ram 6gb --translate --language ja --portnumber 8080
 
-# For remote HLS password protection
-python synthalingua.py --ram 6gb --translate --portnumber 8080 --remote_hls_password_id "user" --remote_hls_password "yourpassword"
+# Start Synthalingua with HTTPS server only  
+python synthalingua.py --ram 6gb --translate --language ja --https 8443
+
+# Start Synthalingua with both HTTP and HTTPS servers
+python synthalingua.py --ram 6gb --translate --language ja --portnumber 8080 --https 8443
+
+# For remote HLS password protection (works with both HTTP and HTTPS)
+python synthalingua.py --ram 6gb --translate --portnumber 8080 --https 8443 --remote_hls_password_id "user" --remote_hls_password "yourpassword"
 ```
 
 ---

--- a/modules/api_backend.py
+++ b/modules/api_backend.py
@@ -236,6 +236,7 @@ class FlaskServerThread(Thread):
         self.app = self.create_app()
         self.server = None
         self.shutdown_event = Event()
+        self.startup_complete = Event()  # Event to signal when startup messages are complete
 
     def create_app(self):
         """Creates and configures the Flask application."""
@@ -325,6 +326,10 @@ class FlaskServerThread(Thread):
             print(f"Starting Flask Server on port: {self.port}")
             print(f"You can access the server at http{'s' if ssl_context else ''}://localhost:{self.port}")
             print(f" To force shutdown the server, delete the '{PID_FILE}' file")
+            print()  # Add empty line to separate multiple server outputs
+            
+            # Signal that startup messages are complete
+            self.startup_complete.set()
             
             while not self.shutdown_event.is_set() and not force_shutdown_flag:
                 try:
@@ -348,23 +353,40 @@ class FlaskServerThread(Thread):
         if self.server:
             self.server.shutdown()
 
-# Global server instance
+# Global server instances
 server_thread = None
+https_server_thread = None
 
-def flask_server(operation, portnumber, use_https=False):
+def flask_server(operation, portnumber, https_port=None):
     """
     Controls the Flask server operation.
     
     Args:
         operation (str): "start" to start the server
-        portnumber (int): Port number for the server
+        portnumber (int): Port number for the HTTP server (can be None)
+        https_port (int): Port number for the HTTPS server (can be None)
     """
-    global server_thread
+    global server_thread, https_server_thread
     if operation == "start":
         create_pid_file()
-        server_thread = FlaskServerThread(portnumber, use_https=use_https)
-        server_thread.daemon = True
-        server_thread.start()
+        
+        # Start HTTP server if port is specified
+        if portnumber:
+            server_thread = FlaskServerThread(portnumber, use_https=False)
+            server_thread.daemon = True
+            server_thread.start()
+            
+            # If we're also starting HTTPS server, wait for HTTP startup to complete
+            if https_port:
+                server_thread.startup_complete.wait()  # Wait for HTTP server messages to finish
+        
+        # Start HTTPS server if port is specified
+        if https_port:
+            https_server_thread = FlaskServerThread(https_port, use_https=True)
+            https_server_thread.daemon = True
+            https_server_thread.start()
+        
+        # Start watchdog thread only once
         global watchdog_thread
         watchdog_thread = threading.Thread(target=watchdog_monitor)
         watchdog_thread.daemon = True
@@ -372,8 +394,15 @@ def flask_server(operation, portnumber, use_https=False):
 
 def kill_server():
     """Force shutdown the server using PID file mechanism."""
-    global server_thread
+    global server_thread, https_server_thread
+    servers_running = []
+    
     if server_thread and server_thread.is_alive():
+        servers_running.append(('HTTP', server_thread))
+    if https_server_thread and https_server_thread.is_alive():
+        servers_running.append(('HTTPS', https_server_thread))
+    
+    if servers_running:
         print("Initiating server shutdown...")
         
         # First try graceful shutdown by deleting PID file
@@ -382,22 +411,22 @@ def kill_server():
         # Wait a moment for watchdog to detect and shutdown
         time.sleep(3)
         
-        # If still running, force it
-        if server_thread.is_alive():
-            print("Server still running, forcing shutdown...")
-            force_shutdown_server()
+        # Check if servers are still running and force shutdown if needed
+        for server_type, thread in servers_running:
+            if thread.is_alive():
+                print(f"{server_type} server still running, forcing shutdown...")
+                force_shutdown_server()
         
-        # Wait for thread to finish
-        server_thread.join(timeout=2)
-        
-        if not server_thread.is_alive():
-            print("Server shutdown complete!")
-        else:
-            print("Server may still be running in background")
+        # Wait for threads to finish
+        for server_type, thread in servers_running:
+            thread.join(timeout=2)
+            if not thread.is_alive():
+                print(f"{server_type} server shutdown complete!")
+            else:
+                print(f"{server_type} server may still be running in background")
     else:
-        print("No server running")
+        print("No servers running")
         # Clean up PID file just in case
-        remove_pid_file()
         remove_pid_file()
 
 # Register cleanup function to remove PID file on exit

--- a/modules/parser_args.py
+++ b/modules/parser_args.py
@@ -300,7 +300,7 @@ def parse_arguments():
     output_grp.add_argument("--save_transcript", action='store_true', help="Automatically save transcription results to text files. Creates timestamped files with complete transcription text in the output directory. Useful for record keeping, further analysis, or batch processing workflows. Files are saved with datetime stamps for easy organization.")
     output_grp.add_argument("--save_folder", default="out", help="Output directory for saved transcripts, subtitle files, and processed audio. Creates directory if it doesn't exist. Use relative path (e.g., 'transcripts') or absolute path (e.g., 'C:/MyTranscripts'). All output files including SRT captions and TXT transcripts are saved here.")
     output_grp.add_argument("--portnumber", default=None, help="TCP port number for web interface server (8000-65535). When specified, starts a web-based control panel accessible via browser at http://localhost:[PORT]. Enables remote control, file uploads, and live transcription monitoring. Use unique port numbers to avoid conflicts with other applications.", type=valid_port_number)
-    output_grp.add_argument("--https", action='store_true', help="Enable HTTPS for the web UI with a self-signed certificate generated at runtime. Falls back to HTTP if certificate setup fails.")
+    output_grp.add_argument("--https", default=None, help="TCP port number for HTTPS web interface server (8000-65535). When specified, starts an additional HTTPS server with self-signed certificate alongside the HTTP server. Example: '--portnumber 8000 --https 8443' runs HTTP on port 8000 and HTTPS on port 8443. Both servers provide the same functionality simultaneously.", type=valid_port_number)
 
     # Filtering & blocklist
     filter_grp = parser.add_argument_group("Filtering & Blocklist")
@@ -356,6 +356,12 @@ def parse_arguments():
     if args.substyle and (not args.subtype or args.subtype != "burn"):
         print(f"{Fore.RED}Error:{Style.RESET_ALL} --substyle can only be used with --subtype burn for customizing burned subtitle appearance.")
         print("The --substyle option requires subtitle burning mode (--subtype burn) to apply visual customizations.")
+        sys.exit(1)
+
+    # Validate that HTTP and HTTPS ports are different
+    if args.portnumber and args.https and args.portnumber == args.https:
+        print(f"{Fore.RED}Error:{Style.RESET_ALL} HTTP and HTTPS cannot use the same port ({args.portnumber}).")
+        print("Please specify different port numbers for --portnumber and --https.")
         sys.exit(1)
 
     return args

--- a/synthalingua.py
+++ b/synthalingua.py
@@ -215,9 +215,17 @@ def main():
             ValueError(f"{args.model_source} is not a valid model source")
 
     # Set up API backend if needed
-    if args.portnumber:
-        print("Port number was set, so spinning up a web server...")
-        api_backend.flask_server(operation="start", portnumber=args.portnumber, use_https=getattr(args, 'https', False))    # Set up temporary directory
+    if args.portnumber or args.https:
+        if args.portnumber and args.https:
+            print(f"Starting web servers on HTTP port {args.portnumber} and HTTPS port {args.https}...")
+        elif args.portnumber:
+            print(f"Starting HTTP web server on port {args.portnumber}...")
+        elif args.https:
+            print(f"Starting HTTPS web server on port {args.https}...")
+        
+        api_backend.flask_server(operation="start", portnumber=args.portnumber, https_port=args.https)
+    
+    # Set up temporary directory
     temp_dir = setup_temp_directory()
 
     # Initialize webhook


### PR DESCRIPTION
This pull request adds support for running both HTTP and HTTPS web servers simultaneously, allowing users to specify separate ports for each. It updates the argument parsing, server startup logic, and documentation to reflect these changes. The shutdown logic is also improved to handle multiple servers gracefully.

**Web server enhancements:**

- Added support for running both HTTP and HTTPS servers at the same time by allowing users to specify `--portnumber` for HTTP and `--https` for HTTPS, each with its own port. The startup and shutdown logic in `api_backend.py` is updated to manage both servers concurrently. [[1]](diffhunk://#diff-dc9766d2f90bb6e199ce23ed9d6571aeb1cc314e301a3a14f1774d20ebb28fcfL351-R405) [[2]](diffhunk://#diff-dc9766d2f90bb6e199ce23ed9d6571aeb1cc314e301a3a14f1774d20ebb28fcfL385-L401) [[3]](diffhunk://#diff-9c74c27e128acfb074779861f315648c89c380989be8af4e668cd548d8ea032dL218-R228)

- Improved the shutdown process to handle multiple server threads, ensuring both HTTP and HTTPS servers are stopped cleanly and providing clearer status messages.

**Argument parsing and validation:**

- Changed the `--https` argument from a boolean flag to a port number, allowing users to specify which port the HTTPS server should use. Added validation to ensure HTTP and HTTPS ports are different. [[1]](diffhunk://#diff-c8ba39105fc1350ea591ba2f6d1f0d5bd379ec4c2030eb072f18d7757f12f7a2L303-R303) [[2]](diffhunk://#diff-c8ba39105fc1350ea591ba2f6d1f0d5bd379ec4c2030eb072f18d7757f12f7a2R361-R366)

**Documentation updates:**

- Updated the `README.md` to document the new `--https` option, provide usage examples for running HTTP, HTTPS, or both servers, and clarify how to access each server locally or over the network. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R241) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R378-R407)

**Internal improvements:**

- Added a startup event to the server thread to coordinate output when launching multiple servers. [[1]](diffhunk://#diff-dc9766d2f90bb6e199ce23ed9d6571aeb1cc314e301a3a14f1774d20ebb28fcfR239) [[2]](diffhunk://#diff-dc9766d2f90bb6e199ce23ed9d6571aeb1cc314e301a3a14f1774d20ebb28fcfR329-R332)